### PR TITLE
feat: add option to public path cdn

### DIFF
--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -63,7 +63,7 @@ module.exports = merge(commonConfig, {
   output: {
     filename: '[name].[chunkhash].js',
     path: path.resolve(process.cwd(), 'dist'),
-    publicPath: process.env.PUBLIC_PATH || '/',
+    publicPath: process.env.PUBLIC_PATH_CDN || process.env.PUBLIC_PATH || '/',
   },
   module: {
     // Specify file-by-file rules to Webpack. Some file-types need a particular kind of loader.


### PR DESCRIPTION
# Based on this proposal to upstream:
https://github.com/openedx/frontend-build/pull/398
# Description
The idea of this commit is to add the option to manage the `publicPath` of webpack to use CDN routing. 
Here you can see that this is managed by webpack, the problem is that `publicPath` is also used in frontend platform with other purposes. So if I override publicPath the built is loading statics from the CDN in the correct behaviour but frontend platform starts with problems.

### webpack recomendation

https://webpack.js.org/configuration/output/#outputpublicpath

### frontend platform
https://github.com/openedx/frontend-platform/blob/master/src/initialize.js#L102

So with this change, I can affect only the webpack behavior without affecting the history web browser of the frontend platform.


### Before
![image](https://github.com/openedx/frontend-build/assets/51926076/6070b9ca-1f7f-46b8-8160-fed7be696f7a)

![2023-06-21_16-21](https://github.com/openedx/frontend-build/assets/51926076/97c00639-90da-49a4-8c9e-d7b65d273108)

### After
![image](https://github.com/openedx/frontend-build/assets/51926076/56632110-f50c-4242-adb2-952a3d231fb6)

![2023-06-21_16-22](https://github.com/openedx/frontend-build/assets/51926076/419a5ecd-d899-4cd3-8909-fe721e2c8acd)
