### PR TITLE
fix: remove env.development import in paragon-webpack-plugin

### DIFF
--- a/lib/plugins/paragon-webpack-plugin/ParagonWebpackPlugin.js
+++ b/lib/plugins/paragon-webpack-plugin/ParagonWebpackPlugin.js
@@ -1,5 +1,4 @@
 const { Compilation, sources } = require('webpack');
-const dotenv = require('dotenv');
 const fs = require('fs');
 const path = require('path');
 const {
@@ -14,12 +13,6 @@ const {
   injectParagonThemeVariantStylesheets,
 } = require('./utils');
 const resolvePrivateEnvConfig = require('../../resolvePrivateEnvConfig');
-
-// Add process env vars. Currently used only for setting the
-// server port and the publicPath
-dotenv.config({
-  path: path.resolve(process.cwd(), '.env.development'),
-});
 
 // Allow private/local overrides of env vars from .env.development for config settings
 // that you'd like to persist locally during development, without the risk of checking


### PR DESCRIPTION
``This PR aims to fix the report about bundling development configurations in production code. 

For context about this issue, you can reference [JIRA-Card](https://edunext.atlassian.net/browse/DS-800)

**How to test**

1. In your tutor environment create [an inline plugin](https://docs.tutor.edly.io/tutorials/plugin.html) with

```
hooks.Filters.ENV_PATCHES.add_items(
    [
        (
            "mfe-dockerfile-post-npm-install",
            """
    RUN npm install --save-dev '@edx/frontend-build@git+https://github.com/eduNEXT/frontend-build.git#dcoa/fix-env-vars'
    """
        ),
    ]
)
```

2. create a new image `tutor images build mfe`
3. Run the environment and check there is not Order History inside the user menu
![image](https://github.com/eduNEXT/frontend-build/assets/66016493/c84a45a7-75a6-47fa-9cb2-3dae32e0b407)

