### PR TITLE
fix: remove env.development import in paragon-webpack-plugin

### DIFF
--- a/lib/plugins/paragon-webpack-plugin/ParagonWebpackPlugin.js
+++ b/lib/plugins/paragon-webpack-plugin/ParagonWebpackPlugin.js
@@ -1,5 +1,4 @@
 const { Compilation, sources } = require('webpack');
-const dotenv = require('dotenv');
 const fs = require('fs');
 const path = require('path');
 const {
@@ -14,12 +13,6 @@ const {
   injectParagonThemeVariantStylesheets,
 } = require('./utils');
 const resolvePrivateEnvConfig = require('../../resolvePrivateEnvConfig');
-
-// Add process env vars. Currently used only for setting the
-// server port and the publicPath
-dotenv.config({
-  path: path.resolve(process.cwd(), '.env.development'),
-});
 
 // Allow private/local overrides of env vars from .env.development for config settings
 // that you'd like to persist locally during development, without the risk of checking


### PR DESCRIPTION
Backport https://github.com/eduNEXT/frontend-build/pull/2